### PR TITLE
docs: add Cloudflare Pages + Workers to subdomains list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,50 @@
-As a developer, sometimes you need a place to host your project, but you don't want to pay for a domain. With these sites, you can get a free, short subdomain for you or your project! 
+As a developer, sometimes you need a place to host your project, but you don't want to pay for a domain. With these sites, you can get a free, short subdomain for you or your project!
 
 # Subdomains
-| Name | Requirements |
-|------|--------------|
-| [js.org](https://js.org) | *Project must be related to javascript* |
-| [mod.land](https://mod.land) | *Project must be related to deno* |
-| [cli.rs](https://github.com/zackify/cli.rs) | *For rust-related* |
-| [wip.la](https://wip.la) | |
-| [cluster.ws](https://cluster.ws) | |
-| [thedev.id](https://thedev.id) | |
-| [is-a.dev](https://is-a.dev) | |
-| [is-a-good.dev](https://is-a-good.dev) | |
-| [eu.org](https://eu.org) | |
-| [is-a-fullstack.dev](https://is-a-fullstack.dev) | |
-| [open-domains.net](https://open-domains.net) | |
-| [js.cool](https://js.cool) | |
-| [developer.li](https://developer.li/) | |
-| [github.io](https://pages.github.com/) | *Must host using Github Pages* |
-| [is-an.app](https://is-an.app/) | |
-| [dee.al](https://github.com/dee-al/domain.dee.al) | |
-| [jsid.dev](https://github.com/namdevel/jsid.dev) | |
-| [vercel.com](http://vercel.com/) | *Must host using Vercel* |
-| [netlify.com](https://netlify.com) | *Must host using Netlify* |
-| [replit.com](https://replit.com) | *Must host using Replit* |
-| [dual.my](https://dual.my/) | |
-| [tilde.tk](https://github.com/youngchief-btw/tilde.tk) | |
-| [env.pm](https://env.pm) | |
-| [yeet.su](https://yeet.su/) | |
-| [getlocalcert.net](https://www.getlocalcert.net) | *For private network use only* |
-| [ngo.us](https://nic.ngo.us) | *For only verified not-for-profit organizations, NGOs* |
-| [PublicZone.org](https://publiczone.org) | Free subdomains across multiple SLDs (.nyc.mn, .cn.st with Mozilla PSL support), funded through charitable donations or the GitHub Developers Program — offering free subdomains to developers who operate a GitHub repository with 100+ stars. |
-| [obl.ong](https://obl.ong) | |
-| [OpenHost](https://registry.openhost.uk) | *Offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it` with Mozilla PSL support* |
-| [pp.ua](https://pp.ua) | |
-| [us.kg](https://nic.us.kg) | *Requires KYC process and annual renewal* |
-| [vtxgames.co.uk](https://github.com/vtxgamesofficial/subdomains) | *Project must be a game* |
+
+| Name                                                             | Requirements                                                                                                                                                                                                                                    |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [js.org](https://js.org)                                         | _Project must be related to javascript_                                                                                                                                                                                                         |
+| [mod.land](https://mod.land)                                     | _Project must be related to deno_                                                                                                                                                                                                               |
+| [cli.rs](https://github.com/zackify/cli.rs)                      | _For rust-related_                                                                                                                                                                                                                              |
+| [wip.la](https://wip.la)                                         |                                                                                                                                                                                                                                                 |
+| [cluster.ws](https://cluster.ws)                                 |                                                                                                                                                                                                                                                 |
+| [thedev.id](https://thedev.id)                                   |                                                                                                                                                                                                                                                 |
+| [is-a.dev](https://is-a.dev)                                     |                                                                                                                                                                                                                                                 |
+| [is-a-good.dev](https://is-a-good.dev)                           |                                                                                                                                                                                                                                                 |
+| [eu.org](https://eu.org)                                         |                                                                                                                                                                                                                                                 |
+| [is-a-fullstack.dev](https://is-a-fullstack.dev)                 |                                                                                                                                                                                                                                                 |
+| [open-domains.net](https://open-domains.net)                     |                                                                                                                                                                                                                                                 |
+| [js.cool](https://js.cool)                                       |                                                                                                                                                                                                                                                 |
+| [developer.li](https://developer.li/)                            |                                                                                                                                                                                                                                                 |
+| [github.io](https://pages.github.com/)                           | _Must host using Github Pages_                                                                                                                                                                                                                  |
+| [is-an.app](https://is-an.app/)                                  |                                                                                                                                                                                                                                                 |
+| [dee.al](https://github.com/dee-al/domain.dee.al)                |                                                                                                                                                                                                                                                 |
+| [jsid.dev](https://github.com/namdevel/jsid.dev)                 |                                                                                                                                                                                                                                                 |
+| [vercel.com](http://vercel.com/)                                 | _Must host using Vercel_                                                                                                                                                                                                                        |
+| [netlify.com](https://netlify.com)                               | _Must host using Netlify_                                                                                                                                                                                                                       |
+| [replit.com](https://replit.com)                                 | _Must host using Replit_                                                                                                                                                                                                                        |
+| [dual.my](https://dual.my/)                                      |                                                                                                                                                                                                                                                 |
+| [tilde.tk](https://github.com/youngchief-btw/tilde.tk)           |                                                                                                                                                                                                                                                 |
+| [env.pm](https://env.pm)                                         |                                                                                                                                                                                                                                                 |
+| [yeet.su](https://yeet.su/)                                      |                                                                                                                                                                                                                                                 |
+| [getlocalcert.net](https://www.getlocalcert.net)                 | _For private network use only_                                                                                                                                                                                                                  |
+| [ngo.us](https://nic.ngo.us)                                     | _For only verified not-for-profit organizations, NGOs_                                                                                                                                                                                          |
+| [PublicZone.org](https://publiczone.org)                         | Free subdomains across multiple SLDs (.nyc.mn, .cn.st with Mozilla PSL support), funded through charitable donations or the GitHub Developers Program — offering free subdomains to developers who operate a GitHub repository with 100+ stars. |
+| [obl.ong](https://obl.ong)                                       |                                                                                                                                                                                                                                                 |
+| [OpenHost](https://registry.openhost.uk)                         | _Offering subdomains on `prvcy.page`, `16-b.it`, `32-b.it`, `64-b.it` with Mozilla PSL support_                                                                                                                                                 |
+| [pp.ua](https://pp.ua)                                           |                                                                                                                                                                                                                                                 |
+| [us.kg](https://nic.us.kg)                                       | _Requires KYC process and annual renewal_                                                                                                                                                                                                       |
+| [vtxgames.co.uk](https://github.com/vtxgamesofficial/subdomains) | _Project must be a game_                                                                                                                                                                                                                        |
+| [pages.dev](https://pages.cloudflare.com/)                       | _Must host using Cloudflare Pages_                                                                                                                                                                                                              |
+| [workers.dev](https://workers.cloudflare.com/)                   | _Must host using Cloudflare Workers_                                                                                                                                                                                                            |
 
 # Contributing
+
 We love it when people contribute to our growing list! If you know of a website to add, create a pull request and add it to the end of the table with any requirements it may have.
 
 In order for a website to be approved, make sure it is not on our [denied list](https://github.com/lukemccrea/FreeSubdomains/blob/main/DENIED.md) and lets you get your own subdomain at no cost. It also must let you use your own custom website and cannot be a website builder (eg. Wix.com).
 
 # Contributers
+
 <img src="https://contrib.rocks/image?repo=lukemccrea/freesubdomains" />


### PR DESCRIPTION
## What

Two new entries at the end of the table:

| Name | Requirements |
|---|---|
| [pages.dev](https://pages.cloudflare.com/) | *Must host using Cloudflare Pages* |
| [workers.dev](https://workers.cloudflare.com/) | *Must host using Cloudflare Workers* |

## Why they meet the inclusion criteria

Per the README:

> It also must let you use your own custom website and cannot be a website builder

- **Pages** — you push your own site (Git repo, static output). Each project auto-gets `<project>.pages.dev`. Custom website, not a builder.
- **Workers** — you deploy your own JS/TS worker. Each worker gets `<worker>.<subdomain>.workers.dev`. Same shape as `vercel.com` / `netlify.com` / `github.io` / `replit.com` already in the list.

## Free tier

- **Pages**: 500 builds/mo, unlimited requests, unlimited bandwidth, unlimited sites. No credit card required. https://developers.cloudflare.com/pages/platform/limits/
- **Workers**: 100k requests/day, 10ms CPU/request. No credit card required. https://developers.cloudflare.com/workers/platform/pricing/

## Not on the DENIED list

Checked `DENIED.md` — only Freenom is banned (unrelated).

Thanks for maintaining FreeSubdomains!